### PR TITLE
相手の駒を取得できる機能を追加

### DIFF
--- a/animal_shogi.rb
+++ b/animal_shogi.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
 require_relative 'board'
+require_relative 'player'
 
 class AnimalShogi
-  FIRST_PLAYER = '先手'
-  SECOND_PLAYER = '後手'
-
   def initialize
-    @current_player = FIRST_PLAYER
+    @first_player = Player.new('先手')
+    @second_player = Player.new('後手')
+    @current_player = @first_player
     @board = Board.new
   end
 
   def run
     loop do
       @board.display
-      print @current_player == FIRST_PLAYER ? '先手: 入力してください > ' : '後手: 入力してください > '
+      print @current_player == @first_player ? '先手: 入力してください > ' : '後手: 入力してください > '
       command = gets.chomp.split(',')
 
       unless valid_format?(command)
@@ -32,13 +32,13 @@ class AnimalShogi
     end
 
     @board.display
-    puts "ゲーム終了 #{@current_player}の勝利！"
+    puts "ゲーム終了 #{@current_player.role}の勝利！"
   end
 
   private
 
   def switch_player
-    @current_player == FIRST_PLAYER ? SECOND_PLAYER : FIRST_PLAYER
+    @current_player == @first_player ? @second_player : @first_player
   end
 
   def valid_format?(command)

--- a/animal_shogi.rb
+++ b/animal_shogi.rb
@@ -22,7 +22,7 @@ class AnimalShogi
         next
       end
 
-      if @board.move_piece(command[0], command[1])
+      if @board.move_piece(command[0], command[1], @current_player)
         break if @board.finished?
 
         @current_player = switch_player

--- a/board.rb
+++ b/board.rb
@@ -34,7 +34,7 @@ class Board
     return false if pos_to.out_of_board?
     return false unless valid_move?(pos_from, pos_to)
 
-    add_piece_to_player(pos_to, player) unless @board[pos_to.col][pos_to.row].empty?
+    add_piece_to_player(pos_to, player) unless @board[pos_to.col][pos_to.row].strip.empty?
     @board[pos_to.col][pos_to.row] = pos_from.animal
     @board[pos_from.col][pos_from.row] = ' '
 

--- a/board.rb
+++ b/board.rb
@@ -27,13 +27,14 @@ class Board
     end
   end
 
-  def move_piece(from, to)
+  def move_piece(from, to, player)
     pos_from = Piece.new(from)
     pos_to = Piece.new(to)
 
     return false if pos_to.out_of_board?
     return false unless valid_move?(pos_from, pos_to)
 
+    add_piece_to_player(pos_to, player) unless @board[pos_to.col][pos_to.row].empty?
     @board[pos_to.col][pos_to.row] = pos_from.animal
     @board[pos_from.col][pos_from.row] = ' '
 
@@ -58,6 +59,10 @@ class Board
 
     moves = valid_moves[piece] || []
     moves.include?([dx, dy])
+  end
+
+  def add_piece_to_player(to, player)
+    player.pieces << @board[to.col][to.row].swapcase
   end
 
   def finished?

--- a/player.rb
+++ b/player.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Player
+  attr_accessor :role
+  attr_reader :pieces
+
+  def initialize(role)
+    @role = role
+    @pieces = []
+  end
+end


### PR DESCRIPTION
## 概要
相手の駒を取得できる機能を追加しました。

## 動作確認
以下のprintデバッグコードを挟んで確認しました
`puts "#{player.role}の駒台：#{player.pieces}"`

駒の取得によって大文字小文字が変化していることも確認できます
```
➜  AnimalShogi git:(feature/add_piece_capture) ✗ ruby run.rb
   | A | B | C |
 1 | e | l | g |
 2 |   | c |   |
 3 |   | C |   |
 4 | G | L | E |
先手: 入力してください > B3C,B2C
先手の駒台：["C"]
   | A | B | C |
 1 | e | l | g |
 2 |   | C |   |
 3 |   |   |   |
 4 | G | L | E |
後手: 入力してください > B1l,B2l
後手の駒台：["c"]
   | A | B | C |
 1 | e |   | g |
 2 |   | l |   |
 3 |   |   |   |
 4 | G | L | E |
先手: 入力してください > A4G,A3G
先手の駒台：["C"]
   | A | B | C |
 1 | e |   | g |
 2 |   | l |   |
 3 | G |   |   |
 4 |   | L | E |
後手: 入力してください >
```