### PR TITLE
手持ちに存在しない駒を指定した場合にエラーメッセージを表示

### DIFF
--- a/board.rb
+++ b/board.rb
@@ -47,8 +47,14 @@ class Board
     return false if pos_to.out_of_board?
     return false unless placeable?(pos_to)
 
+    unless player.pieces.include?(pos_to.animal)
+      puts '指定した駒を所持していません'
+      return false
+    end
+
     @board[pos_to.col][pos_to.row] = pos_to.animal
     remove_piece_from_player(pos_to.animal, player)
+
     true
   end
 


### PR DESCRIPTION
## 概要
手持ちに存在しない駒を指定した場合のエラーメッセージを表示するようにしました。

## 動作確認
```
後手:c
   | A | B | C |
 1 | e |   |   |
 2 |   | l | g |
 3 | G |   |   |
 4 |   | L | E |
先手:C
先手: 入力してください > B3L
指定した駒を所持していません
配置失敗、ターン据え置き
後手:c
   | A | B | C |
 1 | e |   |   |
 2 |   | l | g |
 3 | G |   |   |
 4 |   | L | E |
先手:C
先手: 入力してください > B3C
後手:c
   | A | B | C |
 1 | e |   |   |
 2 |   | l | g |
 3 | G | C |   |
 4 |   | L | E |
先手:
後手: 入力してください >
```